### PR TITLE
Search for existing .byebugrc in ancestors directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Byebug.run_init_script
 ```
 3. For use with Rails, use [byebug-rails-loader](https://github.com/kmewhort/byebug-rails-loader)
 
-Ensure that you start vim from your project directory - this is where Vim Byebug Breakpoints looks for your .byebug.rc.
+Ensure that you start vim from your project directory - this is where Vim Byebug Breakpoints looks for your .byebug.rc first time. If not found it will  go up throught the ancestors until found a .byebug.rc if not It will create one at current directory.
 
 ## Contributing
 

--- a/autoload/vim_byebug_breakpoints.vim
+++ b/autoload/vim_byebug_breakpoints.vim
@@ -6,6 +6,16 @@ ruby <<EOF
   rc_filename = "#{base_dir}/.byebugrc"
   file_in_buffer = Vim::Buffer.current.name
 
+  (0..base_dir.split('/').reject(&:empty?).count - 1).each do |step|
+    path = File.absolute_path(base_dir + '/../' * step)
+    file_path = path + '/.byebugrc'
+    if File.exists?(file_path)
+      base_dir = path
+      rc_filename = "#{base_dir}/.byebugrc"
+      break
+    end
+  end
+
   if File.exist?(rc_filename) && file_in_buffer && file_in_buffer.start_with?(base_dir)
     file_in_buffer = file_in_buffer[base_dir.length+1..-1] 
     lines_with_breaks = []
@@ -33,6 +43,16 @@ ruby <<EOF
   base_dir = Vim::evaluate('getcwd()')
   rc_filename = "#{base_dir}/.byebugrc"
   file_in_buffer = Vim::Buffer.current.name
+
+  (0..base_dir.split('/').reject(&:empty?).count - 1).each do |step|
+    path = File.absolute_path(base_dir + '/../' * step)
+    file_path = path + '/.byebugrc'
+    if File.exists?(file_path)
+      base_dir = path
+      rc_filename = "#{base_dir}/.byebugrc"
+      break
+    end
+  end
 
   if file_in_buffer && file_in_buffer.start_with?(base_dir)
     file_in_buffer = file_in_buffer[base_dir.length+1..-1] 


### PR DESCRIPTION
If you use `set autochdir` vim-byebug-breakpoints creates .byebugrc in current directory. With this change it will search for any .byebugrc in ancestors directories.